### PR TITLE
Dependabotの追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "12:00"
+    timezone: "Asia/Tokyo"


### PR DESCRIPTION
Close #67 

現状、`npm install`するとかなりのセキュリティ関係の警告が出てしまうので、Dependabotを導入することで依存パッケージのバージョンを最新に保ちたいと考えています。

参考：[Dependabot のセキュリティアップデートを設定する - GitHub Docs](https://docs.github.com/ja/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates)