### PR TITLE
Dependabotの実行タイミングの変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "12:00"
-    timezone: "Asia/Tokyo"
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+          timezone: "Asia/Tokyo"


### PR DESCRIPTION
昨年末から導入しているDependabotですが、あまりの頻度の多さにSlackにかなりの量のメッセージが届いてしまっています。
そのため、これまで毎日行なっていたDependabotを、毎週実行に頻度を下げたほうが良いのではないかと考えています。

設定では、毎週月曜日の日本時間午前09:00に実行する設定になっています。
毎月の設定の方が良い等々ありましたらご意見いただけるとありがたいです。