### PR TITLE
公民館データの向き先を変更

### DIFF
--- a/src/pages/Index/Index.tsx
+++ b/src/pages/Index/Index.tsx
@@ -16,7 +16,7 @@ const pointCatalog: PointMeta[] = [
   },
   {
     // TODO: マージしたら向き先修正
-    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/feature/kouminkan/data/kosodate-map/kouminkan.json",
+    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/main/data/kosodate-map/kouminkan.json",
     type: "公民館",
     icon: blueIcon,
   },


### PR DESCRIPTION
open-data-paraserにて公民館データを誤って削除してしまったため、
データを復活させるPRを作成した。 https://github.com/Code-for-Funabashi/open-data-parser/pull/21 
feature dataを参照させるため、map側のURLを書き換えているが、
open-data-parser側の修正が完了したら元に戻す。