### PR TITLE
tooltipの題名を「受入可能人数」から「待機児童数」に変更

### DIFF
--- a/src/components/Map/NurserySchoolTooltip.tsx
+++ b/src/components/Map/NurserySchoolTooltip.tsx
@@ -35,7 +35,7 @@ export const NurserySchoolTooltip = (props: {
         </div>
 
         <div className={tooltip.capacities}>
-          <div className={tooltip.title}>受入可能人数</div>
+          <div className={tooltip.title}>待機児童人数</div>
           <div className={tooltip.contents}>
             <ul>
               <li>


### PR DESCRIPTION
受領したデータは受け入れ可能性人数ではなく、待機児童数だったようなので、
ツールチップの表記をそれにあわせて変更します :bow:
(受け入れ可能性人数の表示については別途検討中です https://codeforfunabashi.slack.com/archives/C01L8QWQN86/p1658711676248519?thread_ts=1658709932.685989&cid=C01L8QWQN86)