### PR TITLE
受け入れ可能人数の表示

### DIFF
--- a/src/components/Map/NurserySchoolTooltip.tsx
+++ b/src/components/Map/NurserySchoolTooltip.tsx
@@ -35,49 +35,49 @@ export const NurserySchoolTooltip = (props: {
         </div>
 
         <div className={tooltip.capacities}>
-          <div className={tooltip.title}>待機児童人数</div>
+          <div className={tooltip.title}>受け入れ可能人数</div>
           <div className={tooltip.contents}>
             <ul>
               <li>
                 0歳
                 <br />
-                {props.point.details.waiting_0yo
-                  ? props.point.details.waiting_0yo
+                {props.point.details.acceptable_0yo
+                  ? props.point.details.acceptable_0yo
                   : "-"}
                 人
               </li>
               <li>
                 1歳 <br />
-                {props.point.details.waiting_1yo
-                  ? props.point.details.waiting_1yo
+                {props.point.details.acceptable_1yo
+                  ? props.point.details.acceptable_1yo
                   : "-"}
                 人
               </li>
               <li>
                 2歳 <br />
-                {props.point.details.waiting_2yo
-                  ? props.point.details.waiting_2yo
+                {props.point.details.acceptable_2yo
+                  ? props.point.details.acceptable_2yo
                   : "-"}
                 人
               </li>
               <li>
                 3歳 <br />
-                {props.point.details.waiting_3yo
-                  ? props.point.details.waiting_3yo
+                {props.point.details.acceptable_3yo
+                  ? props.point.details.acceptable_3yo
                   : "-"}
                 人
               </li>
               <li>
                 4歳 <br />
-                {props.point.details.waiting_4yo
-                  ? props.point.details.waiting_4yo
+                {props.point.details.acceptable_4yo
+                  ? props.point.details.acceptable_4yo
                   : "-"}
                 人
               </li>
               <li>
                 5歳 <br />
-                {props.point.details.waiting_5yo
-                  ? props.point.details.waiting_5yo
+                {props.point.details.acceptable_5yo
+                  ? props.point.details.acceptable_5yo
                   : "-"}
                 人
               </li>

--- a/src/pages/Index/Index.tsx
+++ b/src/pages/Index/Index.tsx
@@ -10,7 +10,7 @@ import "styles/full-screen.scss";
 
 const pointCatalog: PointMeta[] = [
   {
-    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/main/data/kosodate-map/hoikuen.json",
+    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/feature/acceptable-number/data/kosodate-map/hoikuen.json",
     type: "保育園",
     icon: greenIcon,
   },

--- a/src/pages/Index/Index.tsx
+++ b/src/pages/Index/Index.tsx
@@ -16,7 +16,7 @@ const pointCatalog: PointMeta[] = [
   },
   {
     // TODO: マージしたら向き先修正
-    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/feature/kouminkan/data/kosodate-map/kouminkan.json",
+    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/feature/acceptable-number/data/kosodate-map/kouminkan.json",
     type: "公民館",
     icon: blueIcon,
   },

--- a/src/pages/Index/Index.tsx
+++ b/src/pages/Index/Index.tsx
@@ -10,7 +10,7 @@ import "styles/full-screen.scss";
 
 const pointCatalog: PointMeta[] = [
   {
-    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/feature/acceptable-number/data/kosodate-map/hoikuen.json",
+    url: "https://raw.githubusercontent.com/Code-for-Funabashi/open-data-parser/main/data/kosodate-map/hoikuen.json",
     type: "保育園",
     icon: greenIcon,
   },

--- a/src/types/Point.ts
+++ b/src/types/Point.ts
@@ -11,12 +11,12 @@ export interface PointInfoDetail {
   phone_number?: string;
   type?: string;
   acceptable_age?: string;
-  waiting_0yo?: string;
-  waiting_1yo?: string;
-  waiting_2yo?: string;
-  waiting_3yo?: string;
-  waiting_4yo?: string;
-  waiting_5yo?: string;
+  acceptable_0yo?: string;
+  acceptable_1yo?: string;
+  acceptable_2yo?: string;
+  acceptable_3yo?: string;
+  acceptable_4yo?: string;
+  acceptable_5yo?: string;
 }
 
 export interface PointInfo {


### PR DESCRIPTION
# 背景
保育園の受け入れ可能性人数が船橋市よりExcelで公開された。
https://www.city.funabashi.lg.jp/kodomo/hoiku/002/p060892.html
それを画面に表示するため修正を行った


## 修正したこと
- 受け入れ可能人数の表示
- 待機児童人数の削除

## その他
- open-data-parser側のPR https://github.com/Code-for-Funabashi/open-data-parser/pull/23
- 内容は宮内さんのOKをもらってからリリースします。
    - 見てもらう観点
        - 手動で追加した保育園の情報に誤りがないか特に
        - 受け入れ可能性人数の公開について表現に問題がないか