### PR TITLE
Google Analytics 4のタグを追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,15 @@
 
       gtag('config', 'UA-197700032-1');
     </script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLJ5TB17P4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-TLJ5TB17P4');
+    </script>
     <title>船橋子育て地域マップ</title>
   </head>
   <body>


### PR DESCRIPTION
# 背景
Google Analyticsのユニバーサルアナリティクス廃止に対応するため、
Google Analytics 4のタグを追加した。
https://support.google.com/analytics/answer/11583528

ユニバーサルアナリティクスのタグもしばらく並行して残しておく。